### PR TITLE
feature/ drawer persistent show across pages

### DIFF
--- a/src/lib/ui/drawer/components/drawer-menu.svelte
+++ b/src/lib/ui/drawer/components/drawer-menu.svelte
@@ -10,6 +10,7 @@
 	import { directives } from '@root/lib/internal/directives';
 
 	let {
+		data,
 		children,
 		class: className,
 		menuClass = $bindable(
@@ -31,9 +32,9 @@
 	$effect(() => {
 		menuCls = cn(menuClass, className);
 	});
-
+	
 	// Get Drawer Context
-	const { show$, close_drawer, toggle_drawer } = getCtx();
+	const { show$, close_drawer } = getCtx();
 </script>
 
 <!-- Actual Menu -->

--- a/src/lib/ui/drawer/components/drawer.svelte
+++ b/src/lib/ui/drawer/components/drawer.svelte
@@ -12,7 +12,6 @@
 		children,
 		class: className,
 		drawerClass = $bindable(''),
-		active = $bindable(false)
 	}: Props = $props();
 
 	// Setup Drawer's class

--- a/src/lib/ui/drawer/ctx.ts
+++ b/src/lib/ui/drawer/ctx.ts
@@ -5,7 +5,15 @@ import { writable, type Writable } from 'svelte/store';
 import type { tDrawerProps } from './types';
 
 export function createDrawerData(properties: tDrawerProps) {
-	const show$: Writable<boolean> = writable(false);
+	const show$: Writable<boolean> = writable(sessionStorage.getItem("drawer-show") ? true : false);
+
+	show$.subscribe((state_show) => {
+		if (state_show) {
+			sessionStorage.setItem("drawer-show", "yes")
+		} else {
+			sessionStorage.removeItem("drawer-show")
+		}
+	})
 
 	// Close Drawer Function
 	function close_drawer() {

--- a/src/lib/ui/form/components/form-checkbox.svelte
+++ b/src/lib/ui/form/components/form-checkbox.svelte
@@ -46,8 +46,6 @@
         } else {
             inputValue = "no"
         }
-
-        console.log(value, inputValue)
 	}
 </script>
 

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,5 +1,5 @@
-export function load({ url }) {
-    return {
-        url: url.pathname,
-    }
+export const ssr = false;
+
+export async function load({ url }) {
+	return { url: url.pathname };
 }


### PR DESCRIPTION
Now, with the help of `sessionStorage`, the drawer now knows if it should stay open across pages.